### PR TITLE
fix:edit go mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/antlabs/strsim
+module github.com/csh0101/strsim
 
 go 1.14
 


### PR DESCRIPTION
把go mod 的仓库地址改掉 以方便 go get 拉取